### PR TITLE
update entities loot table

### DIFF
--- a/data/minecraft/loot_table/entities/evoker.json
+++ b/data/minecraft/loot_table/entities/evoker.json
@@ -8,6 +8,15 @@
           "condition": "minecraft:killed_by_player"
         },
         {
+          "condition": "minecraft:entity_properties",
+          "entity": "direct_attacker",
+          "predicate": {
+            "type_specific": {
+              "type": "minecraft:player"
+            }
+          }
+        },
+        {
           "condition": "minecraft:random_chance_with_enchanted_bonus",
           "enchanted_chance": {
             "type": "minecraft:linear",
@@ -40,6 +49,9 @@
       "bonus_rolls": 0.0,
       "conditions": [
         {
+          "condition": "minecraft:killed_by_player"
+        },
+        {
           "condition": "minecraft:entity_properties",
           "entity": "this",
           "predicate": {
@@ -66,6 +78,15 @@
       "conditions": [
         {
           "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "direct_attacker",
+          "predicate": {
+            "type_specific": {
+              "type": "minecraft:player"
+            }
+          }
         },
         {
           "condition": "minecraft:entity_properties",

--- a/data/minecraft/loot_table/entities/piglin.json
+++ b/data/minecraft/loot_table/entities/piglin.json
@@ -11,6 +11,15 @@
               "condition": "minecraft:killed_by_player"
             },
             {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
               "condition": "minecraft:location_check",
               "predicate": {
                 "structures": "minecraft:bastion_remnant"
@@ -20,7 +29,7 @@
               "condition": "minecraft:inverted",
               "term": {
                 "condition": "minecraft:entity_properties",
-                "entity": "attacker",
+                "entity": "direct_attacker",
                 "predicate": {
                   "effects": {
                     "more_vault:bastion_omen": {}

--- a/data/minecraft/loot_table/entities/piglin_brute.json
+++ b/data/minecraft/loot_table/entities/piglin_brute.json
@@ -11,10 +11,19 @@
               "condition": "minecraft:killed_by_player"
             },
             {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
               "condition": "minecraft:inverted",
               "term": {
                 "condition": "minecraft:entity_properties",
-                "entity": "attacker",
+                "entity": "direct_attacker",
                 "predicate": {
                   "effects": {
                     "more_vault:bastion_omen": {}
@@ -63,7 +72,16 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "attacker",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
               "predicate": {
                 "effects": {
                   "more_vault:bastion_omen": {}

--- a/data/minecraft/loot_table/entities/shulker.json
+++ b/data/minecraft/loot_table/entities/shulker.json
@@ -33,10 +33,19 @@
               "condition": "minecraft:killed_by_player"
             },
             {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
               "condition": "minecraft:inverted",
               "term": {
                 "condition": "minecraft:entity_properties",
-                "entity": "attacker",
+                "entity": "direct_attacker",
                 "predicate": {
                   "effects": {
                     "more_vault:city_omen": {}
@@ -85,7 +94,16 @@
             },
             {
               "condition": "minecraft:entity_properties",
-              "entity": "attacker",
+              "entity": "direct_attacker",
+              "predicate": {
+                "type_specific": {
+                  "type": "minecraft:player"
+                }
+              }
+            },
+            {
+              "condition": "minecraft:entity_properties",
+              "entity": "direct_attacker",
               "predicate": {
                 "effects": {
                   "more_vault:city_omen": {}

--- a/data/minecraft/loot_table/entities/vindicator.json
+++ b/data/minecraft/loot_table/entities/vindicator.json
@@ -44,6 +44,15 @@
         },
         {
           "condition": "minecraft:entity_properties",
+          "entity": "direct_attacker",
+          "predicate": {
+            "type_specific": {
+              "type": "minecraft:player"
+            }
+          }
+        },
+        {
+          "condition": "minecraft:entity_properties",
           "entity": "this",
           "predicate": {
             "type_specific": {

--- a/data/minecraft/loot_table/entities/warden.json
+++ b/data/minecraft/loot_table/entities/warden.json
@@ -16,6 +16,15 @@
       "conditions": [
         {
           "condition": "minecraft:killed_by_player"
+        },
+        {
+          "condition": "minecraft:entity_properties",
+          "entity": "direct_attacker",
+          "predicate": {
+            "type_specific": {
+              "type": "minecraft:player"
+            }
+          }
         }
       ],
       "entries": [


### PR DESCRIPTION
fix a problem where certain items could be looted by attacking the entity but leaving it to be killed by an entity other than a player